### PR TITLE
versionpress.net and blog.versionpress.net links updated to HTTPS

### DIFF
--- a/content/en/01-getting-started/02-installation-uninstallation.md
+++ b/content/en/01-getting-started/02-installation-uninstallation.md
@@ -91,7 +91,7 @@ VersionPress depends on several external libraries for launching Git processes, 
 
 ## Installation
 
-VersionPress can be obtained via the main [versionpress.net website](http://versionpress.net/). When you have the ZIP file, the installation is pretty standard:
+VersionPress can be obtained via the main [versionpress.net website](https://versionpress.net/). When you have the ZIP file, the installation is pretty standard:
 
 1. Log in to the admin screens
 2. Go to *Plugins > Add New > Upload*

--- a/content/en/01-getting-started/10-using-versionpress.md
+++ b/content/en/01-getting-started/10-using-versionpress.md
@@ -30,7 +30,7 @@ You can also switch to the *Full diff* mode which displays complete contents of 
 
 Related:
 
- - Blog post [VersionPress 2.0: New User Interface](http://blog.versionpress.net/2015/09/versionpress-2-0-new-user-interface/)
+ - Blog post [VersionPress 2.0: New User Interface](https://blog.versionpress.net/2015/09/versionpress-2-0-new-user-interface/)
 
 
 ## Undoing changes
@@ -39,7 +39,7 @@ When something goes wrong, you can use the [Undo and Rollback feature](../featur
 
 Related:
 
- - Blog post [VersionPress 1.0 Walkthrough](http://blog.versionpress.net/2015/05/versionpress-1-0-walkthrough/)
+ - Blog post [VersionPress 1.0 Walkthrough](https://blog.versionpress.net/2015/05/versionpress-1-0-walkthrough/)
 
 
 ## Sync / staging workflows
@@ -48,4 +48,4 @@ Since VersionPress 2.0, [sync / staging workflows](../sync) are supported. See t
 
 Related:
 
- - Blog post [VersionPress 2.0: Simple Staging](http://blog.versionpress.net/2015/09/versionpress-2-0-staging/)
+ - Blog post [VersionPress 2.0: Simple Staging](https://blog.versionpress.net/2015/09/versionpress-2-0-staging/)

--- a/content/en/03-sync/01-concepts.md
+++ b/content/en/03-sync/01-concepts.md
@@ -35,7 +35,7 @@ Let's discuss a workflow that seems basic but actually covers almost any real-wo
  
   **See also**
  
-  The workflow has been showcased in the blog post [VersionPress 2.0: Easy Staging](http://blog.versionpress.net/2015/09/versionpress-2-0-staging/).
+  The workflow has been showcased in the blog post [VersionPress 2.0: Easy Staging](https://blog.versionpress.net/2015/09/versionpress-2-0-staging/).
  
 </div>
 

--- a/content/en/03-sync/_index.md
+++ b/content/en/03-sync/_index.md
@@ -2,7 +2,7 @@
 
 This sections discusses how VersionPress handles multiple site instances like *staging* and *live*, cloning and merging between them, etc.
 
-See also the [blog post on staging](http://blog.versionpress.net/2015/09/versionpress-2-0-staging/).
+See also the [blog post on staging](https://blog.versionpress.net/2015/09/versionpress-2-0-staging/).
 
 <div class="note">
  

--- a/content/en/09-release-notes/80-2.0.md
+++ b/content/en/09-release-notes/80-2.0.md
@@ -2,7 +2,7 @@
 
 VersionPress 2.0 brings the basics of the sync feature, new GUI stack, resolved db.php dependency and a handful of other things.
 
-Released on 12-Oct-2015, read the [announcement blog post](http://blog.versionpress.net/2015/10/versionpress-2-0-released/).
+Released on 12-Oct-2015, read the [announcement blog post](https://blog.versionpress.net/2015/10/versionpress-2-0-released/).
 
 
 <div class="note">
@@ -24,8 +24,8 @@ Released on 12-Oct-2015, read the [announcement blog post](http://blog.versionpr
    * `vp restore-site` – when the only thing you have is a Git repository.
    * `vp apply-changes` – refreshes database to reflect the current state of a site. Useful e.g. after a conflict has been resolved.
 
-    See the [Sync / Workflows section](../sync) for more and [this blog post](http://blog.versionpress.net/2015/09/versionpress-2-0-staging/) with a walkthrough.
- * **New GUI stack** built on top of technologies like React.js, WP REST API and TypeScript. See the blog post [VersionPress 2.0: New User Interface](http://blog.versionpress.net/2015/09/versionpress-2-0-new-user-interface/).
+    See the [Sync / Workflows section](../sync) for more and [this blog post](https://blog.versionpress.net/2015/09/versionpress-2-0-staging/) with a walkthrough.
+ * **New GUI stack** built on top of technologies like React.js, WP REST API and TypeScript. See the blog post [VersionPress 2.0: New User Interface](https://blog.versionpress.net/2015/09/versionpress-2-0-new-user-interface/).
  * **New GUI features**, namely:
    * **Clickable table rows, showing details of every change**. The panel will first show a quick overview of changes (for example, a list of updated properties) with the option to show a full diff which is a bit technical but displays all the details (for example, the option values).
    * **UI for manual commits**. This is useful in scenarios where VersionPress couldn't commit the change automatically, e.g., after a FTP upload or after a manual change. 
@@ -33,7 +33,7 @@ Released on 12-Oct-2015, read the [announcement blog post](http://blog.versionpr
    * **Notification of new commits**. If new commits are detected, a refresh link is displayed.
    * **Times in the main table refresh automatically** so they will now display correct time even if you don't refresh the page.
    * **Other minor UI updates** like an inline warning about the need to fully activate VersionPress or the explanation why commits done pre-activation cannot be undone / rolled back to.
- * **Resolved db.php dependency**. VersionPress no longer requires the `db.php` drop-in to be available, enabling compatibility with various caching, monitoring and other WordPress plugins. See also [blog post with the details](http://blog.versionpress.net/2015/10/the-db-php-issue/).
+ * **Resolved db.php dependency**. VersionPress no longer requires the `db.php` drop-in to be available, enabling compatibility with various caching, monitoring and other WordPress plugins. See also [blog post with the details](https://blog.versionpress.net/2015/10/the-db-php-issue/).
  * **WordPress automatic background updates** are no longer affected by VersionPress. In v1, if VersionPress was activated, WordPress [stopped doing background updates](https://codex.wordpress.org/Configuring_Automatic_Background_Updates). v2 maintains auto-updates if they were enabled before VersionPress activation.
  * **Fixes / updates in automatic change tracking**. Specifically:
    * The biggest one are **translations** which weren't tracked properly in v1.

--- a/content/en/09-release-notes/81-1.0.1.md
+++ b/content/en/09-release-notes/81-1.0.1.md
@@ -2,7 +2,7 @@
 
 Bugfix release for [VersionPress 1.0](./1.0).
 
-Released on 13-May-2015; read the [announcement blog post](http://blog.versionpress.net/2015/05/versionpress-1-0-1-released/).
+Released on 13-May-2015; read the [announcement blog post](https://blog.versionpress.net/2015/05/versionpress-1-0-1-released/).
 
 
 <div class="note">

--- a/content/en/09-release-notes/82-1.0.md
+++ b/content/en/09-release-notes/82-1.0.md
@@ -2,7 +2,7 @@
 
 VersionPress 1.0 is the first stable release, focusing on base functionality like automatic change tracking, undo and rollback and so on.
 
-Released on 16-Apr-2015. See the [announcement blog post](http://blog.versionpress.net/2015/04/versionpress-1-0-released/) or the [walkthrough](http://blog.versionpress.net/2015/05/versionpress-1-0-walkthrough/).
+Released on 16-Apr-2015. See the [announcement blog post](https://blog.versionpress.net/2015/04/versionpress-1-0-released/) or the [walkthrough](https://blog.versionpress.net/2015/05/versionpress-1-0-walkthrough/).
 
 
 <div class="note">

--- a/content/en/09-release-notes/83-1.0-rc3.md
+++ b/content/en/09-release-notes/83-1.0-rc3.md
@@ -2,7 +2,7 @@
 
 RC3 is the last major preparation for the final 1.0 release – it is feature complete, reasonably well-tested and stable. The changes are rather small and technical.
 
-Released on 09-Apr-2015; read the [announcement blog post](http://blog.versionpress.net/2015/04/1-0-rc3-released-and-available-for-anyone-to-test/).
+Released on 09-Apr-2015; read the [announcement blog post](https://blog.versionpress.net/2015/04/1-0-rc3-released-and-available-for-anyone-to-test/).
 
 
 <div class="note">

--- a/content/en/09-release-notes/84-1.0-rc2.md
+++ b/content/en/09-release-notes/84-1.0-rc2.md
@@ -2,7 +2,7 @@
 
 This release does not contain many user-facing changes but is actually one of the biggest one in terms of internal updates. General polish will come as part of the next RC.
 
-Released on 26-Feb-2015; read the [announcement blog post](http://blog.versionpress.net/2015/02/1-0-rc2-released/).
+Released on 26-Feb-2015; read the [announcement blog post](https://blog.versionpress.net/2015/02/1-0-rc2-released/).
 
 
 <div class="note">

--- a/content/en/09-release-notes/_index.md
+++ b/content/en/09-release-notes/_index.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-The current release is **[2.2](./release-notes/2.2)**, released on 15 Dec 2015, and it is an [Early Access release](getting-started/about-eap). VersionPress can be obtained via the main **[versionpress.net](http://versionpress.net/)** site.
+The current release is **[2.2](./release-notes/2.2)**, released on 15 Dec 2015, and it is an [Early Access release](getting-started/about-eap). VersionPress can be obtained via the main **[versionpress.net](https://versionpress.net/)** site.
 
 
 ## Release versioning

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,6 +1,6 @@
 # VersionPress Documentation #
 
-Welcome to [VersionPress](http://versionpress.net/) documentation. VersionPress itself is intuitive to use but some things like core concepts or installation details require more attention and are described here.
+Welcome to [VersionPress](https://versionpress.net/) documentation. VersionPress itself is intuitive to use but some things like core concepts or installation details require more attention and are described here.
 
 <figure style="width: 90%;">
   <img src="../media/successful-activation.png" alt="Hello VersionPress" /> 


### PR DESCRIPTION
Resolves #34.
